### PR TITLE
Add user options about APT map and image

### DIFF
--- a/sat.sh
+++ b/sat.sh
@@ -215,9 +215,9 @@ rec_sat_data () {
 			# map options
 			MAP_OPTS=""
 			if [ "$APT_MAP_QTH" == "yes" ] ; then
-				MAP_OPTS="$MAP_OPTS -n '${LOC_NAME}, ${LOC_COUNTRY}' -l 1"
+				MAP_OPTS="-l 1 -n ${LOC_NAME},${LOC_COUNTRY}"
 			else
-				MAP_OPTS="$MAP_OPTS -l 0"
+				MAP_OPTS="-l 0"
 			fi
 			if [ "$APT_CITIES" == "yes" ] ; then
 				MAP_OPTS="$MAP_OPTS -p 200000"
@@ -247,22 +247,22 @@ rec_sat_data () {
 			# creating standard image & tumbnail
 			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n ${APT_OPTS} -e HVC -K \
 				-q ${WSATP}.wav ${WSATP}.${APT_IMAGE_FORMAT}
-			convert ${WSATP}.${APT_IMAGE_FORMAT} -resize 40% t${WSATP}.jpg
+			convert ${WSATP}.${APT_IMAGE_FORMAT} -resize 40% ${WBASE}/t${SAT}.jpg
 
 			# creating colored image & tumbnail
 			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n ${APT_OPTS} -e MSA \
 				-q ${WSATP}.wav ${WSATP}C.${APT_IMAGE_FORMAT}
-			convert ${WSATP}C.${APT_IMAGE_FORMAT} -resize 40% t${WSATP}C.jpg
+			convert ${WSATP}C.${APT_IMAGE_FORMAT} -resize 40% ${WBASE}/t${SAT}C.jpg
 
 			# creating thermal image & tumbnail
 			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n ${APT_OPTS} -e therm \
 				-q ${WSATP}.wav ${WSATP}T.${APT_IMAGE_FORMAT}
-			convert ${WSATP}T.${APT_IMAGE_FORMAT} -resize 40% t${WSATP}T.jpg
+			convert ${WSATP}T.${APT_IMAGE_FORMAT} -resize 40% ${WBASE}/t${SAT}T.jpg
 
 			# creating 3d image & tumbnail
 			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n ${APT_OPTS} -e anaglyph \
 				-q ${WSATP}.wav ${WSATP}3D.${APT_IMAGE_FORMAT}
-			convert ${WSATP}3D.${APT_IMAGE_FORMAT} -resize 40% t${WSATP}3D.jpg
+			convert ${WSATP}3D.${APT_IMAGE_FORMAT} -resize 40% ${WBASE}/t${SAT}3D.jpg
 		fi
 
 		# copy index to folder

--- a/sat.sh
+++ b/sat.sh
@@ -212,29 +212,57 @@ rec_sat_data () {
 			# adjust the AOS time for the map slant
 			NAOS=`expr ${AOSZ} + 90`
 
+			# map options
+			MAP_OPTS=""
+			if [ "$APT_MAP_QTH" == "yes" ] ; then
+				MAP_OPTS="$MAP_OPTS -n '${LOC_NAME}, ${LOC_COUNTRY}' -l 1"
+			else
+				MAP_OPTS="$MAP_OPTS -l 0"
+			fi
+			if [ "$APT_CITIES" == "yes" ] ; then
+				MAP_OPTS="$MAP_OPTS -p 200000"
+			fi
+			if [ "$APT_ARTIFACTS" == "yes" ] ; then
+				MAP_OPTS="$MAP_OPTS -K 1 -R 1 -C 1 -S 1 -f 1 -F 1"
+			else
+				MAP_OPTS="$MAP_OPTS -K 0 -R 0 -C 1 -S 0 -f 0 -F 0"
+			fi
+
+			# process options
+			APT_OPTS=""
+			if [ "$APT_AUTOCROP" != "yes" ] ; then
+				APT_OPTS="$APT_OPTS -A"
+			fi
+			if [ "$APT_CROP_TELEMETRY" == "yes" ] ; then
+				APT_OPTS="$APT_OPTS -c"
+			fi
+			if [ "$APT_OVERSAMPLE" == "yes" ] ; then
+				APT_OPTS="$APT_OPTS -I"
+			fi
+
 			# creating map overlay
 			wxmap -T "${name}" -H "${CONFPATH}/data.txt" \
-				-p 0 -l 0 -o ${NAOS} ${WSATP}-map.png
+				${MAP_OPTS} -q -o ${NAOS} ${WSATP}-map.png
 
 			# creating standard image & tumbnail
-			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n -I -c -e HVC -K \
-				${WSATP}.wav ${WSATP}.jpg
-			convert ${WSATP}.jpg -resize 40% t${WSATP}.jpg
+			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n ${APT_OPTS} -e HVC -K \
+				-q ${WSATP}.wav ${WSATP}.${APT_IMAGE_FORMAT}
+			convert ${WSATP}.${APT_IMAGE_FORMAT} -resize 40% t${WSATP}.jpg
 
 			# creating colored image & tumbnail
-			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n -I -A -c -e MSA \
-				${WSATP}.wav ${WSATP}C.jpg
-			convert ${WSATP}C.jpg -resize 40% t${WSATP}C.jpg
+			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n ${APT_OPTS} -e MSA \
+				-q ${WSATP}.wav ${WSATP}C.${APT_IMAGE_FORMAT}
+			convert ${WSATP}C.${APT_IMAGE_FORMAT} -resize 40% t${WSATP}C.jpg
 
 			# creating thermal image & tumbnail
-			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n -I -A -c -e therm \
-				${WSATP}.wav ${WSATP}T.jpg
-			convert ${WSATP}T.jpg -resize 40% t${WSATP}T.jpg
+			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n ${APT_OPTS} -e therm \
+				-q ${WSATP}.wav ${WSATP}T.${APT_IMAGE_FORMAT}
+			convert ${WSATP}T.${APT_IMAGE_FORMAT} -resize 40% t${WSATP}T.jpg
 
 			# creating 3d image & tumbnail
-			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n -I -c -e anaglyph \
-				${WSATP}.wav ${WSATP}3D.jpg
-			convert ${WSATP}3D.jpg -resize 40% t${WSATP}3D.jpg
+			wxtoimg -m ${WSATP}-map.png,${SLANT_X},${SLANT_Y} -t n ${APT_OPTS} -e anaglyph \
+				-q ${WSATP}.wav ${WSATP}3D.${APT_IMAGE_FORMAT}
+			convert ${WSATP}3D.${APT_IMAGE_FORMAT} -resize 40% t${WSATP}3D.jpg
 		fi
 
 		# copy index to folder

--- a/sat_data/index.php
+++ b/sat_data/index.php
@@ -76,6 +76,8 @@ foreach ($detailsfile as $vars) {
                 }
             }
 	    </script>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-view,initial-scale=1.0"/>
     </head>
     <body class="body">
     <div class="wrap">

--- a/sat_data/user.conf
+++ b/sat_data/user.conf
@@ -3,7 +3,7 @@
 CALL=CO7WT
 NAME=Pavel
 LOC=FL11bj
-LOC_NAME="Camagüey"
+LOC_NAME="Camaguey"
 LOC_COUNTRY="Cuba"
 
 ######### UI OPTIONS ####################

--- a/sat_data/user.conf
+++ b/sat_data/user.conf
@@ -1,15 +1,84 @@
+######### LOCATION OPTIONS ####################
+#   This options are for the UI and Web showing
 CALL=CO7WT
 NAME=Pavel
 LOC=FL11bj
 LOC_NAME="Camagüey"
 LOC_COUNTRY="Cuba"
 
+######### UI OPTIONS ####################
+
 ### Allow to erase the folder when a bad image or a emtry recording?
 #   set this var to "no" if you are publishing this over the internet
 #   or anyone will be allowed to erase the recorded data!
+#
+# Set this to yes to allow folder removal [yes/no]
 ALLOW_REMOVE_FOLDER="yes"
 
-### map vs image slant correction
+######### APT IMAGES OPTIONS ####################
+
+### Auto-crop images
+#   Raw images are built for the entire audio recording, with a
+#   section of noise to image transition at start and another
+#   of image to noise at the end.
+#
+#   The software can crop this noisy sections but if your antenna
+#   is not good and you have a strong fadding on the middle of the
+#   pass the software can see it and think it's the end transition
+#   and your images can be prematurely croped.
+#
+# Set this to yes to auto crop the images [yes/no]
+APT_AUTOCROP="yes"
+
+### Crop the telemetry stripes
+#   The images have always a tripe of telemetry data on both sides, with
+#   this option you can remove this stripes from the final images.
+#
+# Set this to yes to auto crop telemerty stripes [yes/no]
+APT_CROP_TELEMETRY="yes"
+
+### Oversampling the image from the audio to get a 50% larger image
+#   The software can oversample the audio file to get 50% larger
+#   image than normal. This can lead to some artifacts when
+#   processing some "fake" enhancements, but tolerable.
+#
+# set this option to "yes" to enable image oversampling [yes/no]
+APT_OVERSAMPLE="yes"
+
+### Default image format
+#   The software can output images in varios formats:
+#   - BMP: Full details, bigger size
+#   - PNG: Full details, medium size
+#   - JPEG: Moderate details (low compression), small size
+#
+#   We recommend using PNG/JPEG as BMP is not supported
+#
+# set this option to "jpg" or "png" to use that kind of images
+APT_IMAGE_FORMAT="jpg"
+
+### Place a cross on the QTH/Location of the user
+#   The software can put a cross in the map in the city you
+#   described on the LOC_NAME/LOC_COUNTRY, variables above
+#
+#   Take into account that only citys bigger than 100k people
+#   will be known.
+#
+# set this option to "yes" to place a cross on your location [yes/no]
+APT_MAP_QTH="yes"
+
+### Put major cities on the map
+#   The software can place a dot on major cities [population over 200k]
+#
+# set this option to "yes" to display major cities [yes/no]
+APT_CITIES="yes"
+
+### Draw earth artifacts (rives, lakes, borders...)
+#   The software can draw lakes, rivers, borders, fill heath, lakes, etc
+#
+# set this option to "yes" to draw artifacts on the maps [yes/no]
+APT_ARTIFACTS="yes"
+
+### Map vs image slant correction
 #   You need a precise QTH location and clock source and even with
 #   the you may find that the map is not where it must be, with
 #   this two vars you are able to move the map (not the image)
@@ -19,6 +88,8 @@ SLANT_X=0
 # positive values (pixels) move the map down
 SLANT_Y=10
 
-# make this "" if you don't use proxy at all
+######### PROXY OPTIONS ####################
+
+### make this "" if you don't use proxy at all
 http_proxy="http://10.42.1.10:3128/"
 https_proxy="http://10.42.1.10:3128/"

--- a/www/index.php
+++ b/www/index.php
@@ -25,6 +25,8 @@
                 window.open(sat_folder);
             }
 	    </script>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-view,initial-scale=1.0"/>
     </head>
     <body class="body">
         <div id='page'>


### PR DESCRIPTION
Features included so far:

- [x] Autocrop or full noisy images?
- [x] Normal size or 150% scaling from the audio file?
- [x] Crop the telemetry channel (block bars at both sides of the image)?
- [x] Default Image format [PNG/JPEG]?
- [x] Place a cross on the map on the QTH of the receiving station?
- [x] Allow selecting jpeg or png files as output.
- [x] A cross to mark the QTH of the observer
- [x] Show major cities
- [x] Show earth artifacts (rivers, borders, lakes, etc)
