### PR TITLE
Fix for the '-E wav' missing for rtl_fm in raspios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Fully Automatic Amateur Satellite Ground Station
 
-A setup to build a satellite ground stations that can tune, record and generate images for FM and APT weather satellites.
+A setup to build an amateur satellite ground stations that can tune, record and generate images for APT weather satellites and record audio from Amateur ones.
 
-This is the software recipe, in the hardware part I used an [Orange Pi Prime Board](http://www.orangepi.org/OrangePiPrime/) but you can use any [Single Board Computer](https://en.wikipedia.org/wiki/Single-board_computer), including Raspberry Pis (Note: see section "Installation note in Raspberry Pi OS"), O-droids and even a normal PC or Server.
+This is the software recipe, in the hardware part I used an [Orange Pi Prime Board](http://www.orangepi.org/OrangePiPrime/) (Similar to Raspi 3B+) with [Armbian](https://www.armbian.com/) but you can use any [Single Board Computer](https://en.wikipedia.org/wiki/Single-board_computer), including Raspberry Pis, O-droids and even a normal PC or Server.
 
 The only advice is to use one with a multiple cores and at least 1GB of RAM as some task are resource intensive.
-
-I used [Armbian](https://www.armbian.com/) as OS, but you can manage it to make it work with [RaspiOS](https://www.raspberrypi.org/software/) or any other linux distro with a little of work.
 
 A sample of the main view:
 
@@ -27,22 +25,21 @@ This project is inspired and heavily based on the work of [Luick Klippel](https:
 ## Features
 
 - Web interface to see the next passes, the recorded ones, and details for it.
-- Receive any satellite in FM mode *(SSB is possible but there is no doppler control yet, so no SSB by now)*
+- Receive any satellite in FM mode *(no SSB by now, as we can't do doppler correction yet)*
 - Record the satellite pass and keep the audio for later.
   - APT WX audio is preserved in wav format and 22050 hz of sampling *(the format [wximage](https://wxtoimgrestored.xyz/) needs to work with)*
-  - FM audio satellites is preserved in .mp3 mode but with high quality settings, and other tricks.
+  - FM audio satellites is preserved in .mp3 mode but with high quality settings, and other tricks:
     - The spectrogram of the audio is embedded as album art *(see below)*.
     - The pass details and receiving station data are stored in the mp3 tags.
 - Automatic decode APT images from WX sats (NOAA 15, 18 and 19)
-- For the voice FM sats we craft a spectrogram and embedd the metadata of the pass on the image.
+- For the voice FM sats we craft a spectrogram and embed the metadata of the pass on the image.
 - **NEW** selection for audio processing schema: streamed or step by step (first is good on fast or dedicated systems, the former on slow or multitasking ones) see users.conf while installing for more details.
 
 ## Future features?
 
-- Migrate to python3 for the main processing (doppler adjust, aka SSB tracking/recording?)
-- Control a rotor via [Hamlib](https://hamlib.github.io/).
-- Craft a solution to allow for doppler corrections while receiving *(will allow to receive SSB signals, at least for CW beacons)*
-- Improve the mobile experience (responsive web) WiP...
+- Rotor control via [Hamlib](https://hamlib.github.io/).
+- Doppler control to allow for SSB/CW. 
+- New UI (web) to allow for user authentication, etc.
 
 ## Installation steps
 
@@ -56,7 +53,7 @@ As this tool relies on many tools I will not explain how to setup each one, but 
 
 You need a web server with php installed (at least version 7.x, no MySQL or MariaDB support needed), google has a lot of guides indexed, just google for "install nginx and php in [your-operating-system]"
 
-**RaspiOS users**: If the web server works but does not process php files (try to download the index.php file instead of process & show) you must take a peek on this [tutorial](https://www.raspberrypi.org/documentation/remote-access/web-server/nginx.md) about how to enable php support for nginx.
+**RaspiOS/Raspbian users**: If the web server works but does not process php files (try to download the index.php file instead of process & show) you must take a peek on this [tutorial](https://www.raspberrypi.org/documentation/remote-access/web-server/nginx.md) about how to enable php support for nginx.
 
 - **Predict**
 
@@ -70,7 +67,7 @@ sudo apt install predict
 
 For Armbian you need to compile it from source, you can get it from the [Predict home page](https://www.qsl.net/kd2bd/predict.html).
 
-After installing predict you need to do this aditional step to make it run properly (install some files):
+After installing predict you need to do this additional steps to make it run properly (install some files):
 
 ```sh
 sudo -i
@@ -89,7 +86,7 @@ This wonderful piece of software was deprecated by the original authors but a gr
 
 Just download it here: [WXtoImage deb package for ARM](https://www.wxtoimgrestored.xyz/beta/wxtoimg-armhf-2.11.2-beta.deb) or browse the site for other architectures.
 
-To install it copy it to your SBC computer and run (Debian based distros):
+To install it copy it to your SBC computer and run (Debian based distribution):
 
 ```sh
 sudo dpkg -i wxtoimg-armhf-2.11.2-beta.deb
@@ -98,7 +95,7 @@ sudo aptitude install -f
 # [this will fix any dependency error listed above]
 ```
 
-As I mention this software is abandonware and if you search on the site you will find a generic register credentials.
+As I mention this software is abandon-ware and if you search on the site you will find a generic register credentials.
 
 To register the software in the SBC you need to install it on a linux box with an GUI (can be another SBC or a real linux box); run xwximage and fill your coordinates and settings, register with the credentials and just then locate a hidden file under your home directory called `.wxtoimgrc` and copy it to `/root/.wxtoimgrc` in the SBC. You are done.
 
@@ -109,10 +106,6 @@ You need at least `git` and `make`, in most linux (including SBCs) you are set b
 ```sh
 sudo apt install git make
 ```
-
-- **Installation note in Raspberry Pi OS**
-
-For some unknown reason the `rtl_fm` tool lacks the `-E wav` option as @takagiwa found, the solution is to compile the rtl-fm from upstream, see [this comment](https://github.com/stdevPavelmc/FAASGS/issues/13#issuecomment-774592768) for details.
 
 ## Real install
 
@@ -136,7 +129,7 @@ You will find a proxy setting there to, if you don't use a proxy just leave it a
 
 Next step is to select the satellites you want to monitor, the file is named `sats.json` and it has a very common web format, you can add or remove sats as your need.
 
-Use `sudo nano sats.json` to edit the file, it came by default with all the working NOAA satellites and the working VHF ones, but if you have a dualband antenna you can introduce some UHF sats also.
+Use `sudo nano sats.json` to edit the file, it came by default with all the working NOAA satellites and the working VHF ones, but if you have a dual-band antenna you can introduce some UHF sats also.
 
 Please note that the satellites has a name and a nickname, the name refers to the one that appears in the TLE file and the nickname is a friendly name for us (and must not contain spaces, parenthesis, slashes, etc)
 
@@ -194,4 +187,4 @@ If this is software is of any utility to you; please consider to make a donation
 
 You can improve the software, appoint bugs or fails, donate equipment or money, top up my cell phone, or just share your impressions on social media; details for all of that in the [Contributing](Contributing.md) file.
 
-Any contribution is welcomed.
+Any kind of contribution is welcomed.

--- a/sat.sh
+++ b/sat.sh
@@ -19,6 +19,13 @@ source "${USERCONF}"
 export http_proxy
 export https_proxy
 
+# force streamed audio processing if on raspberry OS to avoid
+# lack of -E option in rtl_fm
+source /etc/os-release
+if [ "$ID" == "raspbian" ] ; then
+	AUDIO_SBS="no"
+fi
+
 main () {
 	# check for arguments
     if [ "$#" -eq 0 ]; then

--- a/sat_data/user.conf
+++ b/sat_data/user.conf
@@ -41,20 +41,26 @@ RTL_PPM=0
 #     Processing is done in a streamed process, all software works on
 #     a stream and piped on each other
 #     - Pros: less SD wear as you only write the final files
-#     - Cons: on slow systems (Raspi 2, Raspi Zero) or when you have
-#       the SBC multitasking you may lose samples and you will get
-#       broken images on NOAAs and skips on the audio sats
+#     - Cons: you may lose audio samples and get cut images on slow
+#       systems (Raspi 1/2, Raspi Zero) or when you have the SBC
+#       multitasking.
 #
 #   # Step by Step audio processing:
-#     Processing is done one operation at a time (reception, resampling,
-#     etc)
+#     Processing is done one operation at a time.
 #     - Pros: less chance of audio skips on slow or multitasking systems
-#     - Cons: More SD wear out, (if you are using an Armbian based SBC
-#       as temp files will be on RAM, so no SD wear out.
+#     - Cons: More SD wear out, (if using Armbian temp files are in /tmp
+#       and temp files will be on zRAM, so no SD wear out)
 #
-# By default we go in the safe way, step by step audio processing that
-# will work on all systems, disable it only if your have a powerful
-# or dedicated system [yes/no]
+#   By default we go in the safe way: step by step audio processing, that
+#   will work on all systems, but there is a catch:
+#
+#   Raspberry Pi versions of rtl_fm software was compiled without an
+#   option to export a WAV stream and hence can't use that method.
+#
+#   So if the script detect it's running Raspbian/RaspiOS it will force
+#   to use the streamed way to avoid that issue
+
+# Use step by step audio processing [yes/no]
 AUDIO_SBS="yes"
 
 ######### APT IMAGES OPTIONS ####################


### PR DESCRIPTION
We introduced a solution to this in a previous PR, so we are making it final here